### PR TITLE
Added usage of --challenge-alias, possibility of different DNA modes per domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,22 @@
 [![Docker stars](https://img.shields.io/docker/stars/nginxproxy/acme-companion.svg)](https://hub.docker.com/r/nginxproxy/acme-companion "Click to view the image on Docker Hub")
 [![Docker pulls](https://img.shields.io/docker/pulls/nginxproxy/acme-companion.svg)](https://hub.docker.com/r/nginxproxy/acme-companion "Click to view the image on Docker Hub")
 
+This fork of [acme-companion](https://github.com/nginx-proxy/acme-companion) brings support for:
+* DNS mode challenge
+* Wildcard domain certificates
+
+Docker image available on dockerhub as [pinidh/acme-companion](https://hub.docker.com/repository/docker/pinidh/acme-companion).
+
 **acme-companion** is a lightweight companion container for [**nginx-proxy**](https://github.com/nginx-proxy/nginx-proxy).
 
 It handles the automated creation, renewal and use of SSL certificates for proxied Docker containers through the ACME protocol.
 
 ### Features:
 * Automated creation/renewal of Let's Encrypt (or other ACME CAs) certificates using [**acme.sh**](https://github.com/acmesh-official/acme.sh).
-* Let's Encrypt / ACME domain validation through `http-01` challenge only.
+* Let's Encrypt / ACME domain validation through `http-01` or dns-01 challenge.
 * Automated update and reload of nginx config on certificate creation/renewal.
 * Support creation of [Multi-Domain (SAN) Certificates](https://github.com/nginx-proxy/acme-companion/blob/main/docs/Let's-Encrypt-and-ACME.md#multi-domains-certificates).
+* Support creation of wildcard certificates.
 * Creation of a strong [RFC7919 Diffie-Hellman Group](https://datatracker.ietf.org/doc/html/rfc7919#appendix-A) at startup.
 * Work with all versions of docker.
 

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -167,7 +167,6 @@ if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
         exit 1
     fi
     check_writable_directory '/etc/nginx/certs'
-    parse_true "${ACME_HTTP_CHALLENGE_LOCATION:=false}" && check_writable_directory '/etc/nginx/vhost.d'
     check_writable_directory '/etc/acme.sh'
     check_writable_directory '/usr/share/nginx/html'
     if [[ -f /app/letsencrypt_user_data ]]; then

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -149,23 +149,35 @@ function check_default_account {
     fi
 }
 
+export NGINX_PROXY_CONTAINER_LABEL="${NGINX_PROXY_CONTAINER_LABEL:-com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy}"
+export DOCKER_GEN_CONTAINER_LABEL="${DOCKER_GEN_CONTAINER_LABEL:-com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen}"
+
 if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
     print_version
     check_docker_socket
-    if [[ -z "$(get_nginx_proxy_container)" ]]; then
-        echo "Error: can't get nginx-proxy container ID !" >&2
-        echo "Check that you are doing one of the following :" >&2
-        echo -e "\t- Use the --volumes-from option to mount volumes from the nginx-proxy container." >&2
-        echo -e "\t- Set the NGINX_PROXY_CONTAINER env var on the letsencrypt-companion container to the name of the nginx-proxy container." >&2
-        echo -e "\t- Label the nginx-proxy container to use with 'com.github.nginx-proxy.nginx'." >&2
-        exit 1
-    elif [[ -z "$(get_docker_gen_container)" ]] && ! is_docker_gen_container "$(get_nginx_proxy_container)"; then
-        echo "Error: can't get docker-gen container id !" >&2
-        echo "If you are running a three containers setup, check that you are doing one of the following :" >&2
-        echo -e "\t- Set the NGINX_DOCKER_GEN_CONTAINER env var on the letsencrypt-companion container to the name of the docker-gen container." >&2
-        echo -e "\t- Label the docker-gen container to use with 'com.github.nginx-proxy.docker-gen'." >&2
-        exit 1
-    fi
+    while true; do
+        if [[ -z "$(get_nginx_proxy_container)" ]]; then
+            echo "Error: can't get nginx-proxy container ID !" >&2
+            echo "Check that you are doing one of the following :" >&2
+            echo -e "\t- Use the --volumes-from option to mount volumes from the nginx-proxy container." >&2
+            echo -e "\t- Set the NGINX_PROXY_CONTAINER env var on the letsencrypt-companion container to the name of the nginx-proxy container." >&2
+            echo -e "\t- Label the nginx-proxy container to use with 'com.github.nginx-proxy.nginx'." >&2
+            sleep 1
+            continue
+        fi
+        break
+    done
+    while true; do
+        if [[ -z "$(get_docker_gen_container)" ]] && ! is_docker_gen_container "$(get_nginx_proxy_container)"; then
+            echo "Error: can't get docker-gen container id !" >&2
+            echo "If you are running a three containers setup, check that you are doing one of the following :" >&2
+            echo -e "\t- Set the NGINX_DOCKER_GEN_CONTAINER env var on the letsencrypt-companion container to the name of the docker-gen container." >&2
+            echo -e "\t- Label the docker-gen container to use with 'com.github.nginx-proxy.docker-gen'." >&2
+            sleep 1
+            continue
+        fi
+        break
+    done
     check_writable_directory '/etc/nginx/certs'
     check_writable_directory '/etc/acme.sh'
     check_writable_directory '/usr/share/nginx/html'

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -184,9 +184,7 @@ function is_docker_gen_container {
 
 function get_docker_gen_container {
     # First try to get the docker-gen container ID from the container label.
-    local legacy_docker_gen_cid; legacy_docker_gen_cid="$(labeled_cid com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen)"
-    local new_docker_gen_cid; new_docker_gen_cid="$(labeled_cid com.github.nginx-proxy.docker-gen)"
-    local docker_gen_cid; docker_gen_cid="${new_docker_gen_cid:-$legacy_docker_gen_cid}"
+    local docker_gen_cid; docker_gen_cid="$(labeled_cid "${DOCKER_GEN_CONTAINER_LABEL}")"
 
     # If the labeled_cid function dit not return anything and the env var is set, use it.
     if [[ -z "$docker_gen_cid" ]] && [[ -n "${NGINX_DOCKER_GEN_CONTAINER:-}" ]]; then
@@ -200,9 +198,7 @@ function get_docker_gen_container {
 function get_nginx_proxy_container {
     local volumes_from
     # First try to get the nginx container ID from the container label.
-    local legacy_nginx_cid; legacy_nginx_cid="$(labeled_cid com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy)"
-    local new_nginx_cid; new_nginx_cid="$(labeled_cid com.github.nginx-proxy.nginx)"
-    local nginx_cid; nginx_cid="${new_nginx_cid:-$legacy_nginx_cid}"
+    local nginx_cid; nginx_cid="$(labeled_cid "${NGINX_PROXY_CONTAINER_LABEL}")"
 
     # If the labeled_cid function dit not return anything ...
     if [[ -z "${nginx_cid}" ]]; then

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -50,12 +50,8 @@ fi
 
 function add_standalone_configuration {
     local domain="${1:?}"
-    if grep -q "server_name ${domain};" /etc/nginx/conf.d/*.conf; then
-        # If the domain is already present in nginx's conf, use the location configuration.
-        add_location_configuration "$domain"
-    else
-        # Else use the standalone configuration.
-        cat > "/etc/nginx/conf.d/standalone-cert-$domain.conf" << EOF
+    [[ "$DEBUG" == 1 ]] && echo "Debug: creating standalone configuration file /etc/nginx/conf.d/standalone-cert-$domain.conf"
+    cat > "/etc/nginx/conf.d/standalone-cert-$domain.conf" << EOF
 server {
     server_name $domain;
     listen 80;
@@ -70,7 +66,6 @@ server {
     }
 }
 EOF
-    fi
 }
 
 function remove_all_standalone_configurations {

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -33,13 +33,6 @@ function in_array() {
     return 1
 }
 
-[[ -z "${VHOST_DIR:-}" ]] && \
- declare -r VHOST_DIR=/etc/nginx/vhost.d
-[[ -z "${START_HEADER:-}" ]] && \
- declare -r START_HEADER='## Start of configuration add by letsencrypt container'
-[[ -z "${END_HEADER:-}" ]] && \
- declare -r END_HEADER='## End of configuration add by letsencrypt container'
-
 function check_nginx_proxy_container_run {
     local _nginx_proxy_container; _nginx_proxy_container=$(get_nginx_proxy_container)
     if [[ -n "$_nginx_proxy_container" ]]; then
@@ -53,88 +46,6 @@ function check_nginx_proxy_container_run {
         echo "$(date "+%Y/%m/%d %T") Error: could not get a nginx-proxy container ID." >&2
         return 1
 fi
-}
-
-function ascending_wildcard_locations {
-    # Given foo.bar.baz.example.com as argument, will output:
-    # - *.bar.baz.example.com
-    # - *.baz.example.com
-    # - *.example.com
-    local domain="${1:?}"
-    local first_label
-    tld_regex="^[[:alpha:]]+$"
-    regex="^[^.]+\..+$"
-    while [[ "$domain" =~ $regex ]]; do
-      first_label="${domain%%.*}"
-      domain="${domain/#"${first_label}."/}"
-      if [[ "$domain" == "*" || "$domain" =~ $tld_regex ]]; then
-        return
-      else
-        echo "*.${domain}"
-      fi
-    done
-}
-
-function descending_wildcard_locations {
-    # Given foo.bar.baz.example.com as argument, will output:
-    # - foo.bar.baz.example.*
-    # - foo.bar.baz.*
-    # - foo.bar.*
-    # - foo.*
-    local domain="${1:?}"
-    local last_label
-    regex="^.+\.[^.]+$"
-    while [[ "$domain" =~ $regex ]]; do
-      last_label="${domain##*.}"
-      domain="${domain/%".${last_label}"/}"
-      if [[ "$domain" == "*" ]]; then
-        return
-      else
-        echo "${domain}.*"
-      fi
-    done
-}
-
-function enumerate_wildcard_locations {
-    # Goes through ascending then descending wildcard locations for a given FQDN
-    local domain="${1:?}"
-    ascending_wildcard_locations "$domain"
-    descending_wildcard_locations "$domain"
-}
-
-function add_location_configuration {
-    local domain="${1:-}"
-    local wildcard_domain
-    # If no domain was passed use default instead
-    [[ -z "$domain" ]] && domain='default'
-
-    # If the domain does not have an exact matching location file, test the possible
-    # wildcard locations files. Use default is no location file is present at all.
-    if [[ ! -f "${VHOST_DIR}/${domain}" ]]; then
-      while read -r wildcard_domain; do
-        if [[ -f "${VHOST_DIR}/${wildcard_domain}" ]]; then
-          domain="$wildcard_domain"
-          break
-        fi
-        domain='default'
-      done <<< "$(enumerate_wildcard_locations "$domain")"
-    fi
-
-    if [[ -f "${VHOST_DIR}/${domain}" && -n $(sed -n "/$START_HEADER/,/$END_HEADER/p" "${VHOST_DIR}/${domain}") ]]; then
-        # If the config file exist and already have the location configuration, end with exit code 0
-        return 0
-    else
-        # Else write the location configuration to a temp file ...
-        echo "$START_HEADER" > "${VHOST_DIR}/${domain}".new
-        cat /app/nginx_location.conf >> "${VHOST_DIR}/${domain}".new
-        echo "$END_HEADER" >> "${VHOST_DIR}/${domain}".new
-        # ... append the existing file content to the temp one ...
-        [[ -f "${VHOST_DIR}/${domain}" ]] && cat "${VHOST_DIR}/${domain}" >> "${VHOST_DIR}/${domain}".new
-        # ... and copy the temp file to the old one (if the destination file is bind mounted, you can't change
-        # its inode from within the container, so mv won't work and cp has to be used), then remove the temp file.
-        cp -f "${VHOST_DIR}/${domain}".new "${VHOST_DIR}/${domain}" && rm -f "${VHOST_DIR}/${domain}".new
-        return 1
-    fi
 }
 
 function add_standalone_configuration {
@@ -169,16 +80,6 @@ function remove_all_standalone_configurations {
       rm -f "$file"
     done
     eval "$old_shopt_options" # Restore shopt options
-}
-
-function remove_all_location_configurations {
-    for file in "${VHOST_DIR}"/*; do
-        [[ -e "$file" ]] || continue
-        if [[ -n $(sed -n "/$START_HEADER/,/$END_HEADER/p" "$file") ]]; then
-            sed "/$START_HEADER/,/$END_HEADER/d" "$file" > "$file".new
-            cp -f "$file".new "$file" && rm -f "$file".new
-        fi
-    done
 }
 
 function check_cert_min_validity {

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -75,6 +75,10 @@ function cleanup_links {
     for cid in "${LETSENCRYPT_CONTAINERS[@]}"; do
       local -n hosts_array="LETSENCRYPT_${cid}_HOST"
       for domain in "${hosts_array[@]}"; do
+        # Skip wildcard domains
+        if [[ "${domain:0:2}" == "*." ]]; then
+          continue
+        fi
         # Add domain to the array storing currently enabled domains.
         ENABLED_DOMAINS+=("$domain")
       done
@@ -151,7 +155,6 @@ function update_cert {
 
     # CLI parameters array used for --issue
     local -a params_issue_arr
-    params_issue_arr+=(--webroot /usr/share/nginx/html)
 
     local -n cert_keysize="LETSENCRYPT_${cid}_KEYSIZE"
     if [[ -z "$cert_keysize" ]] || \
@@ -190,6 +193,24 @@ function update_cert {
         # Use default or user provided ACME end point
         acme_ca_uri="$ACME_CA_URI"
     fi
+
+    # Use DNS mode if configured
+    dns_mode_varname="LETSENCRYPT_${cid}_DNS_MODE"
+    dns_mode="${!dns_mode_varname:-"<no value>"}"
+    if [[ "$dns_mode" != "<no value>" ]]; then
+        params_issue_arr+=(--dns "${dns_mode}")
+        # Apply DNS mode settings
+        # Setting are in the form "export VAR=value ..."
+        dns_mode_settings_varname="LETSENCRYPT_${cid}_DNS_MODE_SETTINGS"
+        dns_mode_settings="${!dns_mode_settings_varname}"
+        if [[ "$dns_mode_settings" != "<no value>" ]]; then
+            eval "$dns_mode_settings"
+        fi
+    else
+        # fallback on webroot mode
+        params_issue_arr+=(--webroot /usr/share/nginx/html)
+    fi
+
     # LETSENCRYPT_TEST overrides LETSENCRYPT_ACME_CA_URI
     local -n test_certificate="LETSENCRYPT_${cid}_TEST"
     if [[ $(lc "$test_certificate") == true ]]; then
@@ -348,10 +369,6 @@ function update_cert {
     for domain in "${hosts_array[@]}"; do
         # Add all the domains to certificate
         params_issue_arr+=(--domain "$domain")
-        # If enabled, add location configuration for the domain
-        if parse_true "${ACME_HTTP_CHALLENGE_LOCATION:=false}"; then
-            add_location_configuration "$domain" || reload_nginx
-        fi
     done
 
     params_issue_arr=("${params_base_arr[@]}" "${params_issue_arr[@]}")
@@ -364,6 +381,10 @@ function update_cert {
     # 0 = success, 2 = RENEW_SKIP
     if [[ $acmesh_return == 0 || $acmesh_return == 2 ]]; then
         for domain in "${hosts_array[@]}"; do
+            # Skip wildcard domains
+            if [[ "${domain:0:2}" == "*." ]]; then
+              continue
+            fi
             if [[ $acme_ca_uri =~ ^https://acme-staging.* ]]; then
                 create_links "_test_$base_domain" "$domain" \
                     && should_reload_nginx='true' \

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -197,37 +197,38 @@ function update_cert {
     local dns_api_applicable=false
 
     local -n dns_challenge_aliases_array="LETSENCRYPT_${cid}_DNS_CHALLENGE_ALIAS"
-    local dns_challenge_aliases_length=${#dns_challenge_aliases_array[*]}
-
-    local -n dns_domain_aliases_array="LETSENCRYPT_${cid}_DNS_DOMAIN_ALIAS"
-    local dns_domain_aliases_length=${#dns_domain_aliases_array[*]}
-
     local -n dns_modes_array="LETSENCRYPT_${cid}_DNS_MODE"
-    local dns_modes_length=${#dns_modes_array[*]}
 
     local dns_mode_settings_varname="LETSENCRYPT_${cid}_DNS_MODE_SETTINGS"
     local dns_mode_settings="${!dns_mode_settings_varname:-"<no value>"}"
 
-    if [ "$dns_modes_length" -gt 0 ] && [[ "$dns_mode_settings" != "<no value>" ]]; then
+    # Either, we have just one dns mode entry (used for all domains)
+    # or we need to have one mode entry for each / per domain
+    # (with LETSENCRYPT_SINGLE_DOMAIN_CERTS set to true,
+    # both is simultaniously true or false, hence still functions)
+    if { [ "${#dns_modes_array[*]}" -eq "1" ] || [ "${#dns_modes_array[*]}" -eq "${#hosts_array[*]}" ]; } && [[ "$dns_mode_settings" != "<no value>" ]]; then
 
-        [[ "$DEBUG" == 1 ]] && echo "Debug: Hosts: ${hosts_array[@]}"
-        [[ "$DEBUG" == 1 ]] && echo "Debug: DNS Mode Settings: ${dns_mode_settings})"
-        [[ "$DEBUG" == 1 ]] && echo "Debug: DNS Modes: ${dns_modes_array[@]} (${dns_modes_length})"
-        [[ "$DEBUG" == 1 ]] && echo "Debug: DNS Challange Aliases: ${dns_challenge_aliases_array[@]} (${dns_challenge_aliases_length})"
-        [[ "$DEBUG" == 1 ]] && echo "Debug: DNS Domain Aliases: ${dns_domain_aliases_array[@]} (${dns_domain_aliases_length})"
+        [[ "$DEBUG" == 1 ]] && echo "Debug: DNS Mode Settings: ${dns_mode_settings}"
+        [[ "$DEBUG" == 1 ]] && echo "Debug: DNS Modes: ${dns_modes_array[*]} (${#dns_modes_array[*]})"
+        [[ "$DEBUG" == 1 ]] && echo "Debug: DNS Challenge Aliases: ${dns_challenge_aliases_array[*]} (${#dns_challenge_aliases_array[*]})"
+        [[ "$DEBUG" == 1 ]] && echo "Debug: Hosts: ${hosts_array[*]} (${#hosts_array[*]})"
+
+        dns_api_applicable=true;
 
         # Apply DNS mode settings
         # Setting are in the form "export VAR=value ..."
         eval "$dns_mode_settings"
-        dns_api_applicable=true;
+
     else
-        # fallback on webroot mode
+        [[ "$DEBUG" == 1 ]] && echo "Debug: No valid DNS challenge config given."
+        [[ "$DEBUG" == 1 ]] && echo "Falling back to webroot mode."
+
         params_issue_arr+=(--webroot /usr/share/nginx/html)
     fi
 
     for hosts_index in "${!hosts_array[@]}"; do
     
-        local domain=${hosts_array[$hosts_index]}
+        local domain="${hosts_array[$hosts_index]}"
       
         # Add all the domains to certificate
         params_issue_arr+=(--domain "$domain")
@@ -235,21 +236,14 @@ function update_cert {
         # Use DNS mode if configured
         if [ "$dns_api_applicable" = true ]; then
 
-            if [ "$hosts_index" -lt "$dns_domain_aliases_length" ]; then
+            local dns_challenge_alias="${dns_challenge_aliases_array[$hosts_index]}"
+            local dns_mode="${dns_modes_array[$hosts_index]}"
 
-                local dns_domain_alias=${dns_domain_aliases_array[$hosts_index]}
-                params_issue_arr+=(--domain-alias "${dns_domain_alias}")
-            fi
-
-            if [ "$hosts_index" -lt "$dns_challenge_aliases_length" ]; then
-
-                local dns_challenge_alias=${dns_challenge_aliases_array[$hosts_index]}
+            if  [ "${dns_challenge_alias}" ]; then
                 params_issue_arr+=(--challenge-alias "${dns_challenge_alias}")
             fi
 
-            if [ "$hosts_index" -lt "$dns_modes_length" ]; then
-
-                local dns_mode=${dns_modes_array[$hosts_index]}
+            if [ "$dns_mode" ]; then
                 params_issue_arr+=(--dns "${dns_mode}")
             fi
         fi

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -440,20 +440,32 @@ function update_certs {
         echo "Warning: /app/letsencrypt_service_data not found, skipping data from containers."
     fi
 
-    # Load settings for standalone certs
+    # Load settings for standalone certs defined into /app/letsencrypt_user_data
     if [[ -f /app/letsencrypt_user_data ]]; then
         if source /app/letsencrypt_user_data; then
-            for cid in "${LETSENCRYPT_STANDALONE_CERTS[@]}"; do
-                local -n hosts_array="LETSENCRYPT_${cid}_HOST"
-                for domain in "${hosts_array[@]}"; do
-                    add_standalone_configuration "$domain"
-                done
-            done
-            reload_nginx
             LETSENCRYPT_CONTAINERS+=( "${LETSENCRYPT_STANDALONE_CERTS[@]}" )
         else
             echo "Warning: could not source /app/letsencrypt_user_data, skipping user data"
         fi
+    fi
+
+    # Configure http-01 challenge for standalone certs
+    if ! [[ -d /etc/nginx/conf.d ]]; then
+        echo "Warning: /etc/nginx/conf.d not mounted; skipping standalone configuration"
+    else
+        should_reload_nginx='false'
+        for cid in "${LETSENCRYPT_CONTAINERS[@]}"; do
+            local -n hosts_array="LETSENCRYPT_${cid}_HOST"
+            for domain in "${hosts_array[@]}"; do
+                # Add the standalone configuration if and only if the domain is
+                # not already present in nginx's conf. If it is present, the location
+                # configuration is expected to be there.
+                if ! grep -q "server_name ${domain};" /etc/nginx/conf.d/*.conf; then
+                    add_standalone_configuration "$domain" && should_reload_nginx=true
+                fi
+            done
+        done
+        [[ "$should_reload_nginx" == 'true' ]] && reload_nginx
     fi
 
     should_reload_nginx='false'

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -194,22 +194,66 @@ function update_cert {
         acme_ca_uri="$ACME_CA_URI"
     fi
 
-    # Use DNS mode if configured
-    dns_mode_varname="LETSENCRYPT_${cid}_DNS_MODE"
-    dns_mode="${!dns_mode_varname:-"<no value>"}"
-    if [[ "$dns_mode" != "<no value>" ]]; then
-        params_issue_arr+=(--dns "${dns_mode}")
+    local dns_api_applicable=false
+
+    local -n dns_challenge_aliases_array="LETSENCRYPT_${cid}_DNS_CHALLENGE_ALIAS"
+    local dns_challenge_aliases_length=${#dns_challenge_aliases_array[*]}
+
+    local -n dns_domain_aliases_array="LETSENCRYPT_${cid}_DNS_DOMAIN_ALIAS"
+    local dns_domain_aliases_length=${#dns_domain_aliases_array[*]}
+
+    local -n dns_modes_array="LETSENCRYPT_${cid}_DNS_MODE"
+    local dns_modes_length=${#dns_modes_array[*]}
+
+    local dns_mode_settings_varname="LETSENCRYPT_${cid}_DNS_MODE_SETTINGS"
+    local dns_mode_settings="${!dns_mode_settings_varname:-"<no value>"}"
+
+    if [ "$dns_modes_length" -gt 0 ] && [[ "$dns_mode_settings" != "<no value>" ]]; then
+
+        [[ "$DEBUG" == 1 ]] && echo "Debug: Hosts: ${hosts_array[@]}"
+        [[ "$DEBUG" == 1 ]] && echo "Debug: DNS Mode Settings: ${dns_mode_settings})"
+        [[ "$DEBUG" == 1 ]] && echo "Debug: DNS Modes: ${dns_modes_array[@]} (${dns_modes_length})"
+        [[ "$DEBUG" == 1 ]] && echo "Debug: DNS Challange Aliases: ${dns_challenge_aliases_array[@]} (${dns_challenge_aliases_length})"
+        [[ "$DEBUG" == 1 ]] && echo "Debug: DNS Domain Aliases: ${dns_domain_aliases_array[@]} (${dns_domain_aliases_length})"
+
         # Apply DNS mode settings
         # Setting are in the form "export VAR=value ..."
-        dns_mode_settings_varname="LETSENCRYPT_${cid}_DNS_MODE_SETTINGS"
-        dns_mode_settings="${!dns_mode_settings_varname}"
-        if [[ "$dns_mode_settings" != "<no value>" ]]; then
-            eval "$dns_mode_settings"
-        fi
+        eval "$dns_mode_settings"
+        dns_api_applicable=true;
     else
         # fallback on webroot mode
         params_issue_arr+=(--webroot /usr/share/nginx/html)
     fi
+
+    for hosts_index in "${!hosts_array[@]}"; do
+    
+        local domain=${hosts_array[$hosts_index]}
+      
+        # Add all the domains to certificate
+        params_issue_arr+=(--domain "$domain")
+
+        # Use DNS mode if configured
+        if [ "$dns_api_applicable" = true ]; then
+
+            if [ "$hosts_index" -lt "$dns_domain_aliases_length" ]; then
+
+                local dns_domain_alias=${dns_domain_aliases_array[$hosts_index]}
+                params_issue_arr+=(--domain-alias "${dns_domain_alias}")
+            fi
+
+            if [ "$hosts_index" -lt "$dns_challenge_aliases_length" ]; then
+
+                local dns_challenge_alias=${dns_challenge_aliases_array[$hosts_index]}
+                params_issue_arr+=(--challenge-alias "${dns_challenge_alias}")
+            fi
+
+            if [ "$hosts_index" -lt "$dns_modes_length" ]; then
+
+                local dns_mode=${dns_modes_array[$hosts_index]}
+                params_issue_arr+=(--dns "${dns_mode}")
+            fi
+        fi
+    done
 
     # LETSENCRYPT_TEST overrides LETSENCRYPT_ACME_CA_URI
     local -n test_certificate="LETSENCRYPT_${cid}_TEST"
@@ -365,11 +409,6 @@ function update_cert {
     # Create directory for the first domain
     mkdir -p "$certificate_dir"
     set_ownership_and_permissions "$certificate_dir"
-
-    for domain in "${hosts_array[@]}"; do
-        # Add all the domains to certificate
-        params_issue_arr+=(--domain "$domain")
-    done
 
     params_issue_arr=("${params_base_arr[@]}" "${params_issue_arr[@]}")
     [[ "$DEBUG" == 1 ]] && echo "Calling acme.sh --issue with the following parameters : ${params_issue_arr[*]}"

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -38,10 +38,8 @@ LETSENCRYPT_CONTAINERS=(
         {{ $DNS_MODE_SETTINGS := trim (coalesce $container.Env.LETSENCRYPT_DNS_MODE_SETTINGS "") }}
         {{ $DNS_MODE := coalesce $container.Env.LETSENCRYPT_DNS_MODE "" | trimSuffix "," | trim }}
         {{ $DNS_CHALLENGE_ALIAS := coalesce $container.Env.LETSENCRYPT_DNS_CHALLENGE_ALIAS "" | trimSuffix "," | trim }}
-        {{ $DNS_DOMAIN_ALIAS := coalesce $container.Env.LETSENCRYPT_DNS_DOMAIN_ALIAS "" | trimSuffix "," | trim }}
         {{ $dnsModes := split $DNS_MODE "," }}
         {{ $dnsChallengeAliases := split $DNS_CHALLENGE_ALIAS "," }}
-        {{ $dnsDomainAliases := split $DNS_DOMAIN_ALIAS "," }}
         {{ $cid := printf "%.12s" $container.ID }}
         {{- "\n" }}# Container {{ $cid }} ({{ $container.Name }})
         {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
@@ -65,25 +63,34 @@ LETSENCRYPT_CONTAINERS=(
                 {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_POST_HOOK="{{ $POST_HOOK }}"
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_DNS_MODE_SETTINGS="{{ $DNS_MODE_SETTINGS }}"
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_DNS_MODE=(
-                    {{ if ne $DNS_MODE "" }}
-                        {{- if lt $hostsIndex (len $dnsModes) -}}
-                            '{{ index $dnsModes $hostsIndex | trim | trimSuffix "." }}'
+                        {{ if ne $DNS_MODE "" }}
+                            {{- if lt $hostsIndex (len $dnsModes) -}}
+                                {{ $dnsMode := index $dnsModes $hostsIndex | trim | trimSuffix "." }}
+                                {{- if ne $dnsMode "" -}}
+                                    '{{ $dnsMode }}'
+                                {{- end -}}
+                            {{- else -}}
+                                {{ $firstDnsMode := index $dnsModes 0 | trim | trimSuffix "." }}
+                                {{- if ne $firstDnsMode "" -}}
+                                    '{{ $firstDnsMode }}'
+                                {{- end -}}
+                            {{- end -}}
                         {{- end -}}
-                    {{ end }}
                 )
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_DNS_CHALLENGE_ALIAS=(
-                    {{ if ne $DNS_CHALLENGE_ALIAS "" }}
-                        {{- if lt $hostsIndex (len $dnsChallengeAliases) -}}
-                            '{{ index $dnsChallengeAliases $hostsIndex | trim | trimSuffix "." }}'
+                        {{ if ne $DNS_CHALLENGE_ALIAS "" }}
+                            {{- if lt $hostsIndex (len $dnsChallengeAliases) -}}
+                                {{ $dnsChallengeAlias := index $dnsChallengeAliases $hostsIndex | trim | trimSuffix "." }}
+                                {{- if and (ne $dnsChallengeAlias "") (ne $dnsChallengeAlias "no") -}}
+                                    '{{ $dnsChallengeAlias }}'
+                                {{- end -}}
+                            {{- else -}}
+                                {{ $firstDnsChallengeAlias := index $dnsChallengeAliases 0 | trim | trimSuffix "." }}
+                                {{- if and (ne $firstDnsChallengeAlias "") (ne $firstDnsChallengeAlias "no") -}}
+                                    '{{ $firstDnsChallengeAlias }}'
+                                {{- end -}}
+                            {{- end -}}
                         {{- end -}}
-                    {{ end }}
-                )
-                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_DNS_DOMAIN_ALIAS=(
-                    {{ if ne $DNS_DOMAIN_ALIAS "" }}
-                        {{- if lt $hostsIndex (len $dnsDomainAliases) -}}
-                            '{{ index $dnsDomainAliases $hostsIndex | trim | trimSuffix "." }}'
-                        {{- end -}}
-                    {{ end }}
                 )
             {{ end }}
         {{ else }}
@@ -109,26 +116,18 @@ LETSENCRYPT_CONTAINERS=(
             {{- "\n" }}ACME_{{ $cid }}_POST_HOOK="{{ $POST_HOOK }}"
             {{- "\n" }}LETSENCRYPT_{{ $cid }}_DNS_MODE_SETTINGS="{{ $DNS_MODE_SETTINGS }}"
             {{- "\n" }}LETSENCRYPT_{{ $cid }}_DNS_MODE=(
-                {{ if ne $DNS_MODE "" }}
-                    {{- range $dnsMode := $dnsModes -}}
-                        '{{ $dnsMode | trim | trimSuffix "." }}'{{ " " }} 
+                    {{ if ne $DNS_MODE "" }}
+                        {{- range $dnsMode := $dnsModes -}}
+                            '{{ $dnsMode | trim | trimSuffix "." }}'{{ " " }} 
+                        {{- end -}}
                     {{- end -}}
-                {{ end }}
             )
             {{- "\n" }}LETSENCRYPT_{{ $cid }}_DNS_CHALLENGE_ALIAS=(
-                {{ if ne $DNS_CHALLENGE_ALIAS "" }}
-                    {{- range $dnsChallengeAlias := $dnsChallengeAliases -}}
-                        '{{ $dnsChallengeAlias | trim | trimSuffix "." }}'{{ " " }} 
+                    {{ if ne $DNS_CHALLENGE_ALIAS "" }}
+                        {{- range $dnsChallengeAlias := $dnsChallengeAliases -}}
+                            '{{ $dnsChallengeAlias | trim | trimSuffix "." }}'{{ " " }} 
+                        {{- end -}}
                     {{- end -}}
-                {{ end }}
-            )
-            {{- "\n" }}LETSENCRYPT_{{ $cid }}_DNS_DOMAIN_ALIAS=(
-
-                {{ if ne $DNS_DOMAIN_ALIAS "" }}
-                    {{- range $dnsDomainAlias := $dnsDomainAliases -}}
-                        '{{ $dnsDomainAlias | trim | trimSuffix "." }}'{{ " " }} 
-                    {{- end -}}
-                {{ end }}
             )
         {{ end }}
     {{ end }}

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -1,8 +1,9 @@
 #!/bin/bash
 # shellcheck disable=SC2034
+{{ $host_variable_name := coalesce $.Env.HOST_VARIABLE_NAME "LETSENCRYPT_HOST" }}
 LETSENCRYPT_CONTAINERS=(
 {{ $orderedContainers := sortObjectsByKeysDesc $ "Created" }}
-{{ range $_, $container := whereExist $orderedContainers "Env.LETSENCRYPT_HOST" }}
+{{ range $_, $container := whereExist $orderedContainers (printf "Env.%s" $host_variable_name) }}
     {{ if trim $container.Env.LETSENCRYPT_HOST }}
         {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
             {{/* Explicit per-domain splitting of the certificate */}}
@@ -18,7 +19,7 @@ LETSENCRYPT_CONTAINERS=(
 {{ end }}
 )
 
-{{ range $hosts, $containers := groupBy $ "Env.LETSENCRYPT_HOST" }}
+{{ range $hosts, $containers := groupBy $ (printf "Env.%s" $host_variable_name) }}
     {{ $hosts := trimSuffix "," $hosts }}
     {{ range $container := $containers }}
         {{/* Trim spaces and set empty values on per-container environment variables */}}

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -34,6 +34,8 @@ LETSENCRYPT_CONTAINERS=(
         {{ $RESTART_CONTAINER := trim (coalesce $container.Env.LETSENCRYPT_RESTART_CONTAINER "") }}
         {{ $PRE_HOOK := trim (coalesce $container.Env.ACME_PRE_HOOK "") }}
         {{ $POST_HOOK := trim (coalesce $container.Env.ACME_POST_HOOK "") }}
+        {{ $DNS_MODE := trim (coalesce $container.Env.LETSENCRYPT_DNS_MODE "") }}
+        {{ $DNS_MODE_SETTINGS := trim (coalesce $container.Env.LETSENCRYPT_DNS_MODE_SETTINGS "") }}
         {{ $cid := printf "%.12s" $container.ID }}
         {{- "\n" }}# Container {{ $cid }} ({{ $container.Name }})
         {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
@@ -55,6 +57,8 @@ LETSENCRYPT_CONTAINERS=(
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_RESTART_CONTAINER="{{ $RESTART_CONTAINER }}"
                 {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_PRE_HOOK="{{ $PRE_HOOK }}"
                 {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_POST_HOOK="{{ $POST_HOOK }}"
+                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_DNS_MODE="{{ $DNS_MODE }}"
+                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_DNS_MODE_SETTINGS="{{ $DNS_MODE_SETTINGS }}"
             {{ end }}
         {{ else }}
             {{/* Default: multi-domain (SAN) certificate */}}
@@ -77,6 +81,8 @@ LETSENCRYPT_CONTAINERS=(
             {{- "\n" }}LETSENCRYPT_{{ $cid }}_RESTART_CONTAINER="{{ $RESTART_CONTAINER }}"
             {{- "\n" }}ACME_{{ $cid }}_PRE_HOOK="{{ $PRE_HOOK }}"
             {{- "\n" }}ACME_{{ $cid }}_POST_HOOK="{{ $POST_HOOK }}"
+            {{- "\n" }}LETSENCRYPT_{{ $cid }}_DNS_MODE="{{ $DNS_MODE }}"
+            {{- "\n" }}LETSENCRYPT_{{ $cid }}_DNS_MODE_SETTINGS="{{ $DNS_MODE_SETTINGS }}"
         {{ end }}
     {{ end }}
 {{ end }}

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -35,13 +35,18 @@ LETSENCRYPT_CONTAINERS=(
         {{ $RESTART_CONTAINER := trim (coalesce $container.Env.LETSENCRYPT_RESTART_CONTAINER "") }}
         {{ $PRE_HOOK := trim (coalesce $container.Env.ACME_PRE_HOOK "") }}
         {{ $POST_HOOK := trim (coalesce $container.Env.ACME_POST_HOOK "") }}
-        {{ $DNS_MODE := trim (coalesce $container.Env.LETSENCRYPT_DNS_MODE "") }}
         {{ $DNS_MODE_SETTINGS := trim (coalesce $container.Env.LETSENCRYPT_DNS_MODE_SETTINGS "") }}
+        {{ $DNS_MODE := coalesce $container.Env.LETSENCRYPT_DNS_MODE "" | trimSuffix "," | trim }}
+        {{ $DNS_CHALLENGE_ALIAS := coalesce $container.Env.LETSENCRYPT_DNS_CHALLENGE_ALIAS "" | trimSuffix "," | trim }}
+        {{ $DNS_DOMAIN_ALIAS := coalesce $container.Env.LETSENCRYPT_DNS_DOMAIN_ALIAS "" | trimSuffix "," | trim }}
+        {{ $dnsModes := split $DNS_MODE "," }}
+        {{ $dnsChallengeAliases := split $DNS_CHALLENGE_ALIAS "," }}
+        {{ $dnsDomainAliases := split $DNS_DOMAIN_ALIAS "," }}
         {{ $cid := printf "%.12s" $container.ID }}
         {{- "\n" }}# Container {{ $cid }} ({{ $container.Name }})
         {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
             {{/* Explicit per-domain splitting of the certificate */}}
-            {{ range $host := split $hosts "," }}
+            {{ range $hostsIndex, $host := split $hosts "," }}
                 {{ $host := trim $host }}
                 {{ $host := trimSuffix "." $host }}
                 {{ $hostHash := sha1 $host }}
@@ -58,8 +63,28 @@ LETSENCRYPT_CONTAINERS=(
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_RESTART_CONTAINER="{{ $RESTART_CONTAINER }}"
                 {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_PRE_HOOK="{{ $PRE_HOOK }}"
                 {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_POST_HOOK="{{ $POST_HOOK }}"
-                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_DNS_MODE="{{ $DNS_MODE }}"
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_DNS_MODE_SETTINGS="{{ $DNS_MODE_SETTINGS }}"
+                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_DNS_MODE=(
+                    {{ if ne $DNS_MODE "" }}
+                        {{- if lt $hostsIndex (len $dnsModes) -}}
+                            '{{ index $dnsModes $hostsIndex | trim | trimSuffix "." }}'
+                        {{- end -}}
+                    {{ end }}
+                )
+                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_DNS_CHALLENGE_ALIAS=(
+                    {{ if ne $DNS_CHALLENGE_ALIAS "" }}
+                        {{- if lt $hostsIndex (len $dnsChallengeAliases) -}}
+                            '{{ index $dnsChallengeAliases $hostsIndex | trim | trimSuffix "." }}'
+                        {{- end -}}
+                    {{ end }}
+                )
+                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_DNS_DOMAIN_ALIAS=(
+                    {{ if ne $DNS_DOMAIN_ALIAS "" }}
+                        {{- if lt $hostsIndex (len $dnsDomainAliases) -}}
+                            '{{ index $dnsDomainAliases $hostsIndex | trim | trimSuffix "." }}'
+                        {{- end -}}
+                    {{ end }}
+                )
             {{ end }}
         {{ else }}
             {{/* Default: multi-domain (SAN) certificate */}}
@@ -82,8 +107,29 @@ LETSENCRYPT_CONTAINERS=(
             {{- "\n" }}LETSENCRYPT_{{ $cid }}_RESTART_CONTAINER="{{ $RESTART_CONTAINER }}"
             {{- "\n" }}ACME_{{ $cid }}_PRE_HOOK="{{ $PRE_HOOK }}"
             {{- "\n" }}ACME_{{ $cid }}_POST_HOOK="{{ $POST_HOOK }}"
-            {{- "\n" }}LETSENCRYPT_{{ $cid }}_DNS_MODE="{{ $DNS_MODE }}"
             {{- "\n" }}LETSENCRYPT_{{ $cid }}_DNS_MODE_SETTINGS="{{ $DNS_MODE_SETTINGS }}"
+            {{- "\n" }}LETSENCRYPT_{{ $cid }}_DNS_MODE=(
+                {{ if ne $DNS_MODE "" }}
+                    {{- range $dnsMode := $dnsModes -}}
+                        '{{ $dnsMode | trim | trimSuffix "." }}'{{ " " }} 
+                    {{- end -}}
+                {{ end }}
+            )
+            {{- "\n" }}LETSENCRYPT_{{ $cid }}_DNS_CHALLENGE_ALIAS=(
+                {{ if ne $DNS_CHALLENGE_ALIAS "" }}
+                    {{- range $dnsChallengeAlias := $dnsChallengeAliases -}}
+                        '{{ $dnsChallengeAlias | trim | trimSuffix "." }}'{{ " " }} 
+                    {{- end -}}
+                {{ end }}
+            )
+            {{- "\n" }}LETSENCRYPT_{{ $cid }}_DNS_DOMAIN_ALIAS=(
+
+                {{ if ne $DNS_DOMAIN_ALIAS "" }}
+                    {{- range $dnsDomainAlias := $dnsDomainAliases -}}
+                        '{{ $dnsDomainAlias | trim | trimSuffix "." }}'{{ " " }} 
+                    {{- end -}}
+                {{ end }}
+            )
         {{ end }}
     {{ end }}
 {{ end }}

--- a/app/nginx_location.conf
+++ b/app/nginx_location.conf
@@ -1,8 +1,0 @@
-location ^~ /.well-known/acme-challenge/ {
-    auth_basic off;
-    auth_request off;
-    allow all;
-    root /usr/share/nginx/html;
-    try_files $uri =404;
-    break;
-}

--- a/app/start.sh
+++ b/app/start.sh
@@ -5,11 +5,6 @@ term_handler() {
     [[ -n "$docker_gen_pid" ]] && kill "$docker_gen_pid"
     [[ -n "$letsencrypt_service_pid" ]] && kill "$letsencrypt_service_pid"
 
-    # shellcheck source=functions.sh
-    source /app/functions.sh
-    remove_all_location_configurations
-    remove_all_standalone_configurations
-
     exit 0
 }
 

--- a/docker-compose-testing.yml
+++ b/docker-compose-testing.yml
@@ -54,7 +54,7 @@ services:
     environment:
     - TESTING_VIRTUAL_HOST=hello.testing.example.com
     - TESTING_LETSENCRYPT_HOST=hello.testing.example.com
-    - TESTING_LETSENCRYPT_TEST=true
+    - LETSENCRYPT_TEST=true
     networks:
       reverse-proxy_bridge:
 

--- a/docker-compose-testing.yml
+++ b/docker-compose-testing.yml
@@ -53,6 +53,7 @@ services:
     restart: always
     environment:
     - TESTING_VIRTUAL_HOST=hello.testing.example.com
+    - HTTPS_METHOD=noredirect
     - TESTING_LETSENCRYPT_HOST=hello.testing.example.com
     - LETSENCRYPT_TEST=true
     networks:

--- a/docker-compose-testing.yml
+++ b/docker-compose-testing.yml
@@ -1,0 +1,70 @@
+version: "3.5"
+
+services:
+  testing_reverse_proxy:
+    image: pinidh/nginx-proxy:latest
+    container_name: testing_reverse_proxy
+    restart: always
+    # Just exposing because we stand behind the main reverse proxy
+    expose:
+      - "80"
+      - "443"
+    volumes:
+      - vhost:/etc/nginx/vhost.d:ro
+      - html:/usr/share/nginx/html
+      - dhparam:/etc/nginx/dhparam
+      - certs:/etc/nginx/certs:ro
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    labels:
+    - testing_reverse_proxy.nginx_proxy=true
+    environment:
+    # vhost variables
+    - VIRTUAL_HOST=*.testing.example.com
+    - VIRTUAL_PORT=80
+    - HTTPS_METHOD=passthrough
+    # nginx-proxy variables
+    - HOST_VARIABLE_NAME=TESTING_VIRTUAL_HOST
+    - HTTPS_PROXY_PROTOCOL=true
+    # Replace with the result of the following command:
+    # docker inspect reverse-proxy_bridge | jq -r '.[0].IPAM.Config[0].Subnet'
+    - REAL_IP_FROM=172.19.0.0/16
+    networks:
+      reverse-proxy_bridge:
+
+  testing_letsencrypt:
+    image: pinidh/letsencrypt-nginx-proxy-companion:latest
+    container_name: testing_letsencrypt
+    restart: always
+    volumes:
+    - acme:/etc/acme.sh
+    - certs:/etc/nginx/certs
+    - html:/usr/share/nginx/html
+    - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      reverse-proxy_bridge:
+    environment:
+    - NGINX_PROXY_CONTAINER_LABEL=testing_reverse_proxy.nginx_proxy
+    - HOST_VARIABLE_NAME=TESTING_LETSENCRYPT_HOST
+    - DEFAULT_EMAIL=admin@example.com
+
+  testing_hello_world:
+    image: dockerbogo/docker-nginx-hello-world:latest
+    container_name: testing_hello_world
+    restart: always
+    environment:
+    - TESTING_VIRTUAL_HOST=hello.testing.example.com
+    - TESTING_LETSENCRYPT_HOST=hello.testing.example.com
+    - TESTING_LETSENCRYPT_TEST=true
+    networks:
+      reverse-proxy_bridge:
+
+volumes:
+  vhost:
+  acme:
+  certs:
+  dhparam:
+  html:
+
+networks:
+  reverse-proxy_bridge:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,65 @@
+version: '3.5'
+
+services:
+  reverse-proxy:
+    image: pinidh/nginx-proxy:latest
+    container_name: reverse-proxy
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      # Uncomment to enable multiple nginx-proxy instances
+      # e.g. to use with docker-compose-testing.yml
+      #- HTTPS_PASSTHROUGH_PORT=444
+    labels:
+    - reverse-proxy.nginx-proxy=true
+    volumes:
+      - vhost:/etc/nginx/vhost.d:ro
+      - html:/usr/share/nginx/html
+      - dhparam:/etc/nginx/dhparam
+      - certs:/etc/nginx/certs:ro
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    networks:
+      bridge:
+
+  letsencrypt:
+    image: pinidh/letsencrypt-nginx-proxy-companion:latest
+    container_name: letsencrypt
+    restart: always
+    depends_on:
+      - reverse-proxy
+    environment:
+      - DEFAULT_EMAIL=admin@example.com
+      - NGINX_PROXY_CONTAINER_LABEL=reverse-proxy.nginx-proxy
+    volumes:
+      - acme:/etc/acme.sh
+      - html:/usr/share/nginx/html
+      - certs:/etc/nginx/certs:rw
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      bridge:
+
+  hello_world:
+    image: dockerbogo/docker-nginx-hello-world:latest
+    container_name: hello_world
+    restart: always
+    environment:
+    - VIRTUAL_HOST=hello.example.com
+    - LETSENCRYPT_HOST=example.com,*.example.com
+    - LETSENCRYPT_DNS_MODE=dns_gandi_livedns
+    - LETSENCRYPT_DNS_MODE_SETTINGS=export GANDI_LIVEDNS_KEY=<your_api_key>
+    # Uncomment when testing
+    #- LETSENCRYPT_TEST=true
+    networks:
+      bridge:
+
+volumes:
+  vhost:
+  acme:
+  html:
+  dhparam:
+  certs:
+
+networks:
+  bridge:

--- a/docs/DNS-mode-challenge.md
+++ b/docs/DNS-mode-challenge.md
@@ -1,0 +1,37 @@
+## DNS mode challenge configuration
+
+To use DNS mode challenge, define `LETSENCRYPT_DNS_MODE` and `LETSENCRYPT_DNS_MODE_SETTINGS` environment variables in the client container:
+
+	  environment:
+	  - LETSENCRYPT_DNS_MODE=<dns_provider_script_name>
+	  - LETSENCRYPT_DNS_MODE_SETTINGS=export <provider_setting>=<value> ...
+
+You find the `<dns_provider_script_name>` by browsing the `acme.sh` `dnsapi` folder [1]. the variable must hold the script name without the `.sh` extension.
+
+[1] https://github.com/acmesh-official/acme.sh/tree/master/dnsapi
+
+Examples:
+
+* To use Gandi LiveDNS:
+
+		- LETSENCRYPT_DNS_MODE=dns_gandi_livedns
+* To use DuckDNS:
+
+		- LETSENCRYPT_DNS_MODE=dns_duckdns
+
+To find about a provider's settings, read the comments provided at the begining of the related script.
+
+Example:
+
+* `dnsapi/dns_gandi_livedns.sh` has this comment:
+
+		# Requires GANDI API KEY set in GANDI_LIVEDNS_KEY set as environment variable
+   Then the settings would be:
+  
+		- LETSENCRYPT_DNS_MODE_SETTINGS=export GANDI_LIVEDNS_KEY=<your_gandi_api_key>	
+* `dnsapi/dns_duckdns.sh` has this comment:
+
+		# export DuckDNS_Token="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+   Then the settings would be:
+
+		- LETSENCRYPT_DNS_MODE_SETTINGS=export DuckDNS_Token=<your_duckdns_token>


### PR DESCRIPTION
Since I needed to use acme.sh's --challenge-alias, I forked and wrote it in.
So I wanna participate also here and give my changes back to you, if you are interessted :-)

Allows for something like:
```
LETSENCRYPT_HOST=foo.domain.example,bar.other-domain.example
VIRTUAL_HOST=foo.domain.example,bar.other-domain.example
LETSENCRYPT_DNS_CHALLENGE_ALIAS=foo.validation-domain.example,bar.other-validation-domain.example
LETSENCRYPT_DNS_MODE=dns_inwx,dns_dynv6
LETSENCRYPT_DNS_MODE_SETTINGS=export INWX_User="my_user" INWX_Password="----" INWX_Shared_Secret="........." DYNV6_TOKEN="????"
```

- If only one DNS Mode is given, it is used for all domains in the cert.
- If only one challenge alias is given, it is used for all domains in the cert.
- Mode config simply takes all exports for all used APIs.

Can be mixed with un-aliased auth - use "no" instead of alias domain at the according place(s) in the challange alias list like:
```
LETSENCRYPT_HOST=foo.domain.example,bar.other-domain.example,test.third-domain.example
VIRTUAL_HOST=foo.domain.example,bar.other-domain.example,test.third-domain.example
LETSENCRYPT_DNS_CHALLENGE_ALIAS=foo.validation-domain.example,no,test.some-validation-domain.example
LETSENCRYPT_DNS_MODE=dns_inwx,dns_dynv6,dns_inwx
LETSENCRYPT_DNS_MODE_SETTINGS=export INWX_User="my_user" INWX_Password="----" INWX_Shared_Secret="........." DYNV6_TOKEN="????"
```

I even tried implementing --domain-alias, but acme.sh's docu sadly is a little bit ambiguous how to mix this with the other two modes, does not support "no" for that parameter and hence filtering for that placeholder was difficult - so I removed those trials again.

I tested for both modes, single cert per domain and SAN.
For single cert per domain, the bullet points above are regarded by filtering out "no" and also applying only one given mode and / or alias for all created certs (see sources).

I am sorry for having no idea how to implement tests fitting your existing ones, so I have to leave that part to someone else.
Might be good to test the whole thing more intensively, seems to fit my use case / needs, so at some point I stoped looking for other edge-cases.

If I find some other bugs, I can do a new pull request, If you like.